### PR TITLE
Drop obsolete cpan.org URL from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
   * My extended documentation: <http://perl.overmeer.net/CPAN/>
   * Development via GitHub: <https://github.com/markov2/perl5-XML-Compile-SOAP>
   * Download from CPAN: <ftp://ftp.cpan.org/pub/CPAN/authors/id/M/MA/MARKOV/>
-  * Indexed from CPAN: <http://search.cpan.org/~markov/XML-Compile-SOAP/>
-    and <https://metacpan.org/release/XML-Compile-SOAP>
+  * Indexed from CPAN: <https://metacpan.org/release/XML-Compile-SOAP>
 
 The XML-Compile suite is a large set of modules for various XML related
 standards.  This optional component implements the SOAP 1.1 protocol,


### PR DESCRIPTION
Having both the cpan.org and the metacpan.org URLs is redundant since the former redirects to the latter as of June last year: https://log.perl.org/2018/05/goodbye-search-dot-cpan-dot-org.html